### PR TITLE
Code refactor, module Mars :arrow_right: MarsRovers rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ $ rake # to run the tests suite
 
 $ irb
 
-$LOAD_PATH.push('lib')
+$LOAD_PATH.unshift('lib')
 require 'play'
-Mars::Play.run('tests/fixtures/input.txt') # or any other path with an input
+MarsRovers::Play.run('tests/fixtures/input.txt') # or any other path with an input
 ```
 
 :see_no_evil:

--- a/lib/error.rb
+++ b/lib/error.rb
@@ -1,3 +1,0 @@
-module Mars
-  class Error < StandardError;end
-end

--- a/lib/mars_rovers/error.rb
+++ b/lib/mars_rovers/error.rb
@@ -1,0 +1,3 @@
+module MarsRovers
+  class Error < StandardError; end
+end

--- a/lib/mars_rovers/file_parser.rb
+++ b/lib/mars_rovers/file_parser.rb
@@ -1,8 +1,8 @@
-require 'error'
-require 'mars_plateu'
-require 'rover'
+require 'mars_rovers/error'
+require 'mars_rovers/mars_plateu'
+require 'mars_rovers/rover'
 
-module Mars
+module MarsRovers
 
   module FileParser
 
@@ -16,7 +16,7 @@ module Mars
 
           begin
             File.open(path) do |f|
-              result[:planet] = MarsPlateu.new(*f.readline.strip.split)
+              result[:planet] = _get_planet_class.new(*f.readline.strip.split)
 
               f.each_slice(2) do |rover_config|
                 rover = _rover_by_config(rover_config)
@@ -34,13 +34,23 @@ module Mars
         end
       end
 
-      private def _rover_by_config(rover_config)
+      private
+      
+      def _rover_by_config(rover_config)
         if rover_config.size == 2 && !rover_config.include?("\n")
           {
-            obj: Rover.new(*rover_config.first.strip.split),
+            obj: _get_rover_class.new(*rover_config.first.strip.split),
             commands: rover_config.last.strip
           }
         end
+      end
+
+      def _get_rover_class
+        Rover
+      end
+
+      def _get_planet_class
+        MarsPlateu
       end
 
     end

--- a/lib/mars_rovers/mars_plateu.rb
+++ b/lib/mars_rovers/mars_plateu.rb
@@ -1,7 +1,7 @@
-require 'error'
-require 'utils'
+require 'mars_rovers/error'
+require 'mars_rovers/utils'
 
-module Mars
+module MarsRovers
 
   class MarsPlateu
     include Utils

--- a/lib/mars_rovers/rover.rb
+++ b/lib/mars_rovers/rover.rb
@@ -1,7 +1,7 @@
-require 'error'
-require 'utils'
+require 'mars_rovers/error'
+require 'mars_rovers/utils'
 
-module Mars
+module MarsRovers
 
   class Rover
     include Utils
@@ -17,7 +17,7 @@ module Mars
     attr_accessor :x, :y, :orientation
     attr_reader :planet
 
-    def initialize(x = nil, y = nil, orientation = nil) # make default 0,0, N?
+    def initialize(x = nil, y = nil, orientation = nil)
       unless x && y && orientation
         raise Error.new(
           'Should be initialized with x and y position coordinates '\

--- a/lib/mars_rovers/utils.rb
+++ b/lib/mars_rovers/utils.rb
@@ -1,6 +1,6 @@
-require 'error'
+require 'mars_rovers/error'
 
-module Mars
+module MarsRovers
   module Utils
     private
 

--- a/lib/play.rb
+++ b/lib/play.rb
@@ -1,11 +1,11 @@
-require 'file_parser'
+require 'mars_rovers/file_parser'
 
-module Mars
-  VERSION = '0.0.1'
+module MarsRovers
+  VERSION = '0.0.2'
 
   module Play
     def self.run(file_path)
-      parsed_data = Mars::FileParser.parse!(file_path)
+      parsed_data = FileParser.parse!(file_path)
       rovers = parsed_data[:rovers]
       planet = parsed_data[:planet]
       result = ''
@@ -21,6 +21,7 @@ module Mars
         result << "#{rover.x} #{rover.y} #{rover.orientation}\n"
       end
 
+      puts
       puts result
       result.strip
     end

--- a/tests/file_parser_test.rb
+++ b/tests/file_parser_test.rb
@@ -1,18 +1,19 @@
-require 'minitest/autorun'
+require_relative './test_helper'
 
-require 'error'
-require 'file_parser'
+require 'mars_rovers/file_parser'
 
 FIXTURE_EXAMPLE_PATH = 'tests/fixtures/input.txt'
 
 class TestFileParser < Minitest::Test
 
   def test_unxistent_input_file_raises_error
-    assert_raises(Mars::Error) { Mars::FileParser.parse!('abc.txt') }
+    assert_raises(MarsRovers::Error) do
+      MarsRovers::FileParser.parse!('abc.txt')
+    end
   end
 
   def test_load_config_into_data
-    data = Mars::FileParser.parse!(FIXTURE_EXAMPLE_PATH)
+    data = MarsRovers::FileParser.parse!(FIXTURE_EXAMPLE_PATH)
 
     assert_equal 5, data[:planet].x
     assert_equal 5, data[:planet].y

--- a/tests/mars_plateu_test.rb
+++ b/tests/mars_plateu_test.rb
@@ -1,21 +1,20 @@
-require 'minitest/autorun'
+require_relative './test_helper'
 
-require 'error'
-require 'mars_plateu'
+require 'mars_rovers/mars_plateu'
 
 class TestMarsPlateu < Minitest::Test
   def test_should_be_initialized_with_coordinates
-    assert_raises(Mars::Error) { Mars::MarsPlateu.new }
+    assert_raises(MarsRovers::Error) { MarsRovers::MarsPlateu.new }
   end
 
   def test_initialized_with_coordinates
-    mars = Mars::MarsPlateu.new(1, 5)
+    mars = MarsRovers::MarsPlateu.new(1, 5)
     assert_equal 1, mars.x
     assert_equal 5, mars.y
   end
 
   def test_shoul_be_initialized_with_postitive_numbers
-    assert_raises(Mars::Error) { Mars::MarsPlateu.new('xfdsf', 5) }
+    assert_raises(MarsRovers::Error) { MarsRovers::MarsPlateu.new('xfdsf', 5) }
   end
 
 end

--- a/tests/play_test.rb
+++ b/tests/play_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative './test_helper'
 
 require 'play'
 require_relative 'file_parser_test'
@@ -6,7 +6,7 @@ require_relative 'file_parser_test'
 class TestPlay < Minitest::Test
 
   def test_run_returns_processed_commads_output
-    assert_equal "1 3 N\n5 1 E", Mars::Play.run(FIXTURE_EXAMPLE_PATH)
+    assert_equal "1 3 N\n5 1 E", MarsRovers::Play.run(FIXTURE_EXAMPLE_PATH)
   end
 
 end

--- a/tests/rover_test.rb
+++ b/tests/rover_test.rb
@@ -1,35 +1,34 @@
-require 'minitest/autorun'
+require_relative './test_helper'
 
-require 'error'
-require 'mars_plateu'
-require 'rover'
+require 'mars_rovers/mars_plateu'
+require 'mars_rovers/rover'
 
 class TestRover < Minitest::Test
   def setup
-    @rover = Mars::Rover.new(5, 5, 'N')
+    @rover = MarsRovers::Rover.new(5, 5, 'N')
   end
 
   def test_should_be_initialized_with_position_and_orientation
-    assert_raises(Mars::Error) { Mars::Rover.new }
+    assert_raises(MarsRovers::Error) { MarsRovers::Rover.new }
   end
 
   def test_initialized_with_position_and_orientation
-    rover = Mars::Rover.new(1, 5, 'S')
+    rover = MarsRovers::Rover.new(1, 5, 'S')
     assert_equal 1, rover.x
     assert_equal 5, rover.y
     assert_equal 'S', rover.orientation
   end
 
   def test_should_be_initialized_with_postitive_numbers
-    assert_raises(Mars::Error) { Mars::Rover.new('xfdsf', 5, 'N') }
+    assert_raises(MarsRovers::Error) { MarsRovers::Rover.new('xfdsf', 5, 'N') }
   end
 
   def test_rover_orientation_restricted_by_defined_list
-    assert_raises(Mars::Error) { Mars::Rover.new(1, 5, 'X') }
+    assert_raises(MarsRovers::Error) { MarsRovers::Rover.new(1, 5, 'X') }
   end
 
   def test_could_change_position_and_orientation
-    rover = Mars::Rover.new(1, 5, 'S')
+    rover = MarsRovers::Rover.new(1, 5, 'S')
     rover.x = 2
     rover.y = 1
     rover.orientation = 'N'
@@ -116,26 +115,26 @@ class TestRover < Minitest::Test
   end
 
   def test_rover_could_not_be_sent_back_or_another_planet
-    home = Mars::MarsPlateu.new(9, 9)
+    home = MarsRovers::MarsPlateu.new(9, 9)
     @rover.send_to_planet(_mars)
 
-    assert_raises(Mars::Error) { @rover.send_to_planet(home) }
+    assert_raises(MarsRovers::Error) { @rover.send_to_planet(home) }
   end
 
   def test_could_not_land_on_small_planet
-    assert_raises(Mars::Error) do
-      @rover.send_to_planet(Mars::MarsPlateu.new(1, 1))
+    assert_raises(MarsRovers::Error) do
+      @rover.send_to_planet(MarsRovers::MarsPlateu.new(1, 1))
     end
 
-    assert_raises(Mars::Error) do
-      @rover.send_to_planet(Mars::MarsPlateu.new(10, 4))
+    assert_raises(MarsRovers::Error) do
+      @rover.send_to_planet(MarsRovers::MarsPlateu.new(10, 4))
     end
 
-    assert_raises(Mars::Error) do
-      @rover.send_to_planet(Mars::MarsPlateu.new(4, 10))
+    assert_raises(MarsRovers::Error) do
+      @rover.send_to_planet(MarsRovers::MarsPlateu.new(4, 10))
     end
 
-    same_size_planet = Mars::MarsPlateu.new(5, 5)
+    same_size_planet = MarsRovers::MarsPlateu.new(5, 5)
     assert_equal same_size_planet, @rover.send_to_planet(same_size_planet)
   end
 
@@ -193,6 +192,6 @@ class TestRover < Minitest::Test
   private
 
   def _mars
-    @mars ||= Mars::MarsPlateu.new(6, 6)
+    @mars ||= MarsRovers::MarsPlateu.new(6, 6)
   end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,0 +1,4 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+
+require 'mars_rovers/error'


### PR DESCRIPTION
- move the code under MarsRovers module to be consistent
  with package name
- add the `test_helper` to reduce repeatable requires
- make planet and rover classes accesable via
  getters in `file_parser` for easier changes in a possible future
- beautify the tests output with `minitest/pride`
